### PR TITLE
Defeat sprite cacheing in Weight, Cargo, AllCargo and Utility screens

### DIFF
--- a/ExcavOS/Screens/AllCargoScreen.cs
+++ b/ExcavOS/Screens/AllCargoScreen.cs
@@ -61,6 +61,8 @@ namespace IngameScript
                             Type = SpriteType.TEXTURE,
                             Data = "SquareSimple",
                             Color = surface.ScriptBackgroundColor,
+                            Position = new Vector2(0, 0),
+                            Size = new Vector2(0, 0)
                         });
                     }
                     Painter.SetCurrentSurfaceAndFrame(surface, frame);

--- a/ExcavOS/Screens/AllCargoScreen.cs
+++ b/ExcavOS/Screens/AllCargoScreen.cs
@@ -60,7 +60,7 @@ namespace IngameScript
                         {
                             Type = SpriteType.TEXTURE,
                             Data = "SquareSimple",
-                            Color = surface.BackgroundColor,
+                            Color = surface.ScriptBackgroundColor,
                         });
                     }
                     Painter.SetCurrentSurfaceAndFrame(surface, frame);

--- a/ExcavOS/Screens/AllCargoScreen.cs
+++ b/ExcavOS/Screens/AllCargoScreen.cs
@@ -25,6 +25,7 @@ namespace IngameScript
         public class AllCargoScreen : ScreenHandler<ExcavOSContext>
         {
             public new const string SCREEN_NAME = "Cargo";
+            private bool MakeSpriteCacheDirty = false;
             private readonly StringBuilder sb = new StringBuilder();
 
             public AllCargoScreen(ExcavOSContext context) : base(context)
@@ -52,6 +53,16 @@ namespace IngameScript
             {
                 using (var frame = surface.DrawFrame())
                 {
+                    MakeSpriteCacheDirty = !MakeSpriteCacheDirty;
+                    if (MakeSpriteCacheDirty)
+                    {
+                        frame.Add(new MySprite()
+                        {
+                            Type = SpriteType.TEXTURE,
+                            Data = "SquareSimple",
+                            Color = surface.BackgroundColor,
+                        });
+                    }
                     Painter.SetCurrentSurfaceAndFrame(surface, frame);
                     float margin = Painter.Width >= 512.0f ? 25.0f : 5.0f;
                     float gap = Painter.Width >= 512.0f ? 10.0f : 2.0f;

--- a/ExcavOS/Screens/CargoScreen.cs
+++ b/ExcavOS/Screens/CargoScreen.cs
@@ -25,6 +25,7 @@ namespace IngameScript
         public class CargoScreen : ScreenHandler<ExcavOSContext>
         {
             public new const string SCREEN_NAME = "CargoOre";
+            private bool MakeSpriteCacheDirty = false;
             private readonly StringBuilder sb = new StringBuilder();
 
             public CargoScreen(ExcavOSContext context) : base(context)
@@ -52,6 +53,16 @@ namespace IngameScript
             {
                 using (var frame = surface.DrawFrame())
                 {
+                    MakeSpriteCacheDirty = !MakeSpriteCacheDirty;
+                    if (MakeSpriteCacheDirty)
+                    {
+                        frame.Add(new MySprite()
+                        {
+                            Type = SpriteType.TEXTURE,
+                            Data = "SquareSimple",
+                            Color = surface.BackgroundColor,
+                        });
+                    }
                     Painter.SetCurrentSurfaceAndFrame(surface, frame);
                     float margin = Painter.Width >= 512.0f ? 25.0f : 5.0f;
                     float gap = Painter.Width >= 512.0f ? 10.0f : 2.0f;

--- a/ExcavOS/Screens/CargoScreen.cs
+++ b/ExcavOS/Screens/CargoScreen.cs
@@ -61,6 +61,8 @@ namespace IngameScript
                             Type = SpriteType.TEXTURE,
                             Data = "SquareSimple",
                             Color = surface.ScriptBackgroundColor,
+                            Position = new Vector2(0, 0),
+                            Size = new Vector2(0, 0)
                         });
                     }
                     Painter.SetCurrentSurfaceAndFrame(surface, frame);

--- a/ExcavOS/Screens/CargoScreen.cs
+++ b/ExcavOS/Screens/CargoScreen.cs
@@ -60,7 +60,7 @@ namespace IngameScript
                         {
                             Type = SpriteType.TEXTURE,
                             Data = "SquareSimple",
-                            Color = surface.BackgroundColor,
+                            Color = surface.ScriptBackgroundColor,
                         });
                     }
                     Painter.SetCurrentSurfaceAndFrame(surface, frame);

--- a/ExcavOS/Screens/UtilityScreen.cs
+++ b/ExcavOS/Screens/UtilityScreen.cs
@@ -45,6 +45,8 @@ namespace IngameScript
                             Type = SpriteType.TEXTURE,
                             Data = "SquareSimple",
                             Color = surface.ScriptBackgroundColor,
+                            Position = new Vector2(0, 0),
+                            Size = new Vector2(0, 0)
                         });
                     }
                     Painter.SetCurrentSurfaceAndFrame(surface, frame);

--- a/ExcavOS/Screens/UtilityScreen.cs
+++ b/ExcavOS/Screens/UtilityScreen.cs
@@ -25,6 +25,7 @@ namespace IngameScript
         public class UtilityScreen : ScreenHandler<ExcavOSContext>
         {
             public new const string SCREEN_NAME = "Utility";
+            private bool MakeSpriteCacheDirty = false;
 
             private readonly StringBuilder sb = new StringBuilder();
 
@@ -36,6 +37,16 @@ namespace IngameScript
             {
                 using (var frame = surface.DrawFrame())
                 {
+                    MakeSpriteCacheDirty = !MakeSpriteCacheDirty;
+                    if (MakeSpriteCacheDirty)
+                    {
+                        frame.Add(new MySprite()
+                        {
+                            Type = SpriteType.TEXTURE,
+                            Data = "SquareSimple",
+                            Color = surface.BackgroundColor,
+                        });
+                    }
                     Painter.SetCurrentSurfaceAndFrame(surface, frame);
                     float margin = Painter.Width >= 512.0f ? 25.0f : 5.0f;
                     float gap = Painter.Width >= 512.0f ? 10.0f : 2.0f;

--- a/ExcavOS/Screens/UtilityScreen.cs
+++ b/ExcavOS/Screens/UtilityScreen.cs
@@ -44,7 +44,7 @@ namespace IngameScript
                         {
                             Type = SpriteType.TEXTURE,
                             Data = "SquareSimple",
-                            Color = surface.BackgroundColor,
+                            Color = surface.ScriptBackgroundColor,
                         });
                     }
                     Painter.SetCurrentSurfaceAndFrame(surface, frame);

--- a/ExcavOS/Screens/WeightScreen.cs
+++ b/ExcavOS/Screens/WeightScreen.cs
@@ -45,6 +45,8 @@ namespace IngameScript
                             Type = SpriteType.TEXTURE,
                             Data = "SquareSimple",
                             Color = surface.ScriptBackgroundColor,
+                            Position = new Vector2(0, 0),
+                            Size = new Vector2(0, 0)
                         });
                     }
                     Painter.SetCurrentSurfaceAndFrame(surface, frame);

--- a/ExcavOS/Screens/WeightScreen.cs
+++ b/ExcavOS/Screens/WeightScreen.cs
@@ -25,6 +25,7 @@ namespace IngameScript
         public class WeightScreen : ScreenHandler<ExcavOSContext>
         {
             public new const string SCREEN_NAME = "Weight";
+            private bool MakeSpriteCacheDirty = false;
  
             public WeightScreen(ExcavOSContext context) : base(context)
             {
@@ -36,6 +37,16 @@ namespace IngameScript
 
                 using (var frame = surface.DrawFrame())
                 {
+                    MakeSpriteCacheDirty = !MakeSpriteCacheDirty;
+                    if (MakeSpriteCacheDirty)
+                    {
+                        frame.Add(new MySprite()
+                        {
+                            Type = SpriteType.TEXTURE,
+                            Data = "SquareSimple",
+                            Color = surface.BackgroundColor,
+                        });
+                    }
                     Painter.SetCurrentSurfaceAndFrame(surface, frame);
 
                     bool roverMode = _context._systemmanager.LiftThrusters.Count == 0;

--- a/ExcavOS/Screens/WeightScreen.cs
+++ b/ExcavOS/Screens/WeightScreen.cs
@@ -44,7 +44,7 @@ namespace IngameScript
                         {
                             Type = SpriteType.TEXTURE,
                             Data = "SquareSimple",
-                            Color = surface.BackgroundColor,
+                            Color = surface.ScriptBackgroundColor,
                         });
                     }
                     Painter.SetCurrentSurfaceAndFrame(surface, frame);


### PR DESCRIPTION
In multiplayer, sprites are cached on the client and the server only sends changed sprites on a display surface's stack. Additionally, sprites are not sent to players that are too far away from the display. The combination of these two effects is that a player can walk towards a display, and only see updated sprites, leading to incomplete information being visible on the display.

This pull request inserts a trivial sprite (a four pixel background-coloured rectangle) at the bottom of the sprite stack every alternate time the surface sprites are composed, which defeates the cache, causing displays to show all information to all players.

This issue was [marked as resolved ](https://support.keenswh.com/spaceengineers/pc/topic/1-192-021-lcd-scripts-using-sprites-dont-work-in-mp) by Keen, but this appears not to be the case. This is *probably* not the [32 metre bug](https://support.keenswh.com/spaceengineers/pc/topic/1-197-168-fix-programmable-block-sprite-streaming-for-clients).